### PR TITLE
Fixing undo/redo

### DIFF
--- a/src/model/ProxyProject.py
+++ b/src/model/ProxyProject.py
@@ -92,7 +92,7 @@ class ProxyProject(Project):
     def get_selected_config_index(self: ProjectSnapshot) -> int:
         return self.get_selected_config_index()
 
-    @__snapshot()
+    @__snapshot(new_snapshot=True)
     def set_selected_config_index(self: ProjectSnapshot, index: int):
         return self.set_selected_config_index(index)
 

--- a/src/model/ProxyProject.py
+++ b/src/model/ProxyProject.py
@@ -92,7 +92,7 @@ class ProxyProject(Project):
     def get_selected_config_index(self: ProjectSnapshot) -> int:
         return self.get_selected_config_index()
 
-    @__snapshot(new_snapshot=True)
+    @__snapshot()
     def set_selected_config_index(self: ProjectSnapshot, index: int):
         return self.set_selected_config_index(index)
 

--- a/src/view/ProcessingWidget.py
+++ b/src/view/ProcessingWidget.py
@@ -89,6 +89,7 @@ class ProcessingWidget(QWidget):
             return item
 
         # combo box update
+        self.combo_box.blockSignals(True)
         config_names = self.__controller.get_config_display_names()
         config_idx = self.__controller.get_project().get_selected_config_index()
         self.combo_box.clear()
@@ -96,6 +97,7 @@ class ProcessingWidget(QWidget):
             for name in config_names:
                 self.combo_box.addItem(name)
         self.combo_box.setCurrentIndex(config_idx)
+        self.combo_box.blockSignals(False)
 
         # clear the model for the tree view to add updated data
         self.__model.clear()
@@ -135,6 +137,7 @@ class ProcessingWidget(QWidget):
     def set_selected_config(self):
         """Sets the selected config using the current index."""
         self.__controller.select_config(self.combo_box.currentIndex())
+        self.initiate_update()
 
     def set_config_settings_item(self, name: str, value: str):
         """


### PR DESCRIPTION
Currently undo does not return into the previous ProjectSnapshot for derivatives/alternatives/etc.
This is because in the `ProcessingWidget` an update resets the ComboBox. This causes three calls to `set_selected_config()` as changes in the Box are connected to that function.
```
        # combo box update
        config_names = self.__controller.get_config_display_names()
        config_idx = self.__controller.get_project().get_selected_config_index()
        self.combo_box.clear()
        if config_names is not None:
            for name in config_names:
                self.combo_box.addItem(name)
        self.combo_box.setCurrentIndex(config_idx)
```

`set_selected_config()` however creates a new snapshot for every call, as it can not differ between an actual change by the user or a change caused by the update.